### PR TITLE
chore: Add --force-from-block-height flag, BLOCK_HEIGHT to config.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ CREATE TABLE defuse_assets (
 PRIMARY KEY (defuse_asset_id, price_updated_at)
 ORDER BY (defuse_asset_id, price_updated_at);
 
+
 CREATE MATERIALIZED VIEW mv_defuse_assets
 REFRESH EVERY 1 DAY APPEND TO defuse_assets AS (
     WITH json_rows AS (
@@ -155,6 +156,7 @@ REFRESH EVERY 1 DAY APPEND TO defuse_assets AS (
         , item.symbol symbol
     FROM json_rows
 );
+
 
 CREATE TABLE events (
     block_height                UInt64 COMMENT 'The height of the block',
@@ -180,6 +182,8 @@ CREATE TABLE events (
 PRIMARY KEY (block_height, related_receipt_id, index_in_log)
 ORDER BY (block_height, related_receipt_id, index_in_log)
 SETTINGS index_granularity = 8192;
+
+
 CREATE TABLE silver_nep_245_events (
     block_height                UInt64 COMMENT 'The height of the block',
     block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
@@ -206,6 +210,8 @@ CREATE TABLE silver_nep_245_events (
 PRIMARY KEY (block_height, related_receipt_id, event, old_owner_id, new_owner_id, token_id)
 ORDER BY (block_height, related_receipt_id, event, old_owner_id, new_owner_id, token_id)
 SETTINGS allow_nullable_key = true, index_granularity = 8192;
+
+
 CREATE MATERIALIZED VIEW mv_silver_nep_245_events TO silver_nep_245_events (
     block_height                UInt64,
     block_timestamp             DateTime64(9, 'UTC'),
@@ -244,6 +250,7 @@ SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, executio
 FROM tokens_flattened
 SETTINGS function_json_value_return_type_allow_nullable = true;
 
+
 CREATE TABLE silver_dip4_token_diff (
     block_height                UInt64 COMMENT 'The height of the block',
     block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
@@ -271,6 +278,8 @@ CREATE TABLE silver_dip4_token_diff (
 PRIMARY KEY (block_height, related_receipt_id, intent_hash)
 ORDER BY (block_height, related_receipt_id, intent_hash)
 SETTINGS index_granularity = 8192;
+
+
 CREATE MATERIALIZED VIEW mv_silver_dip4_token_diff TO silver_dip4_token_diff (
     block_height                UInt64,
     block_timestamp             DateTime64(9, 'UTC'),
@@ -360,6 +369,8 @@ WITH decoded_events AS (
 SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id, coalesce(JSON_VALUE(data_row, '$.public_key'), '') AS public_key
 FROM decoded_events
 SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+
+
 CREATE TABLE silver_dip4_intents_executed (
     block_height                UInt64 COMMENT 'The height of the block',
     block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
@@ -429,6 +440,8 @@ CREATE TABLE silver_dip4_fee_changed (
 PRIMARY KEY (block_height, related_receipt_id)
 ORDER BY (block_height, related_receipt_id)
 SETTINGS index_granularity = 8192;
+
+
 CREATE MATERIALIZED VIEW silver_mv_dip4_fee_changed TO silver_dip4_fee_changed (
     block_height                UInt64,
     block_timestamp             DateTime64(9, 'UTC'),
@@ -452,6 +465,7 @@ WITH decoded_events AS (
 SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, coalesce(JSON_VALUE(data_row, '$.old_fee'), '') AS old_fee, coalesce(JSON_VALUE(data_row, '$.new_fee'), '') AS new_fee
 FROM decoded_events
 SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+
 
 CREATE VIEW gold_view_intents_metrics (
     day Date,
@@ -482,6 +496,7 @@ WHERE (symbol != '') AND (blockchain != '')
 GROUP BY ALL
 ORDER BY 1 ASC;
 
+
 CREATE TABLE transactions (
     block_height         UInt64 COMMENT 'The height of the block',
     block_timestamp      DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
@@ -498,6 +513,7 @@ CREATE TABLE transactions (
 PRIMARY KEY (block_height, transaction_hash)
 ORDER BY (block_height, transaction_hash)
 SETTINGS index_granularity = 8192;
+
 
 CREATE TABLE receipts (
     block_height              UInt64 COMMENT 'The height of the block',
@@ -517,6 +533,7 @@ CREATE TABLE receipts (
 PRIMARY KEY (block_height, receipt_id)
 ORDER BY (block_height, receipt_id)
 SETTINGS index_granularity = 8192;
+
 
 CREATE TABLE execution_outcomes (
     block_height              UInt64 COMMENT 'The height of the block',

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,10 @@ use clap::Parser;
 #[derive(Parser, Clone)]
 #[clap(author, version, about)]
 pub struct AppConfig {
+    // Fallback block height to start if no previous height is found in the database
+    #[clap(long, env = "BLOCK_HEIGHT", default_value = "0")]
+    pub block_height: u64,
+
     /// Clickhouse server URL (env: CLICKHOUSE_URL)
     #[clap(long, env = "CLICKHOUSE_URL")]
     pub clickhouse_url: String,
@@ -47,6 +51,12 @@ pub struct AppConfig {
         requires = "metrics_basic_auth_user"
     )]
     pub metrics_basic_auth_password: Option<String>,
+
+    /// Forces the indexer to start from the specified block height provided via --block-height,
+    /// even if a higher block height is found in the database. This is useful when reindexing
+    /// from a specific point is needed.
+    #[clap(long, requires = "block_height", hide = true)]
+    pub force_from_block_height: bool,
 }
 
 pub fn init_tracing() {

--- a/src/database.rs
+++ b/src/database.rs
@@ -10,8 +10,9 @@ pub fn init_clickhouse_client(config: &AppConfig) -> Client {
 }
 
 pub async fn get_last_height(client: &Client) -> Result<u64, clickhouse::error::Error> {
+    tracing::info!("Fetching last indexed block height from ClickHouse...");
     client
-        .query("SELECT max(block_height) FROM events")
+        .query("SELECT max(block_height) FROM transactions")
         .fetch_one::<u64>()
         .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
 
     let block_height: u64 = config.block_height;
 
-    let last_height = get_last_height(&client).await.unwrap_or(0);
+    let last_height = get_last_height(&client).await?;
     let start_block = if config.force_from_block_height {
         tracing::warn!("Forcing reindex from block height: {}", block_height);
         block_height


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New CLI options to set and (optionally) force the indexer start block height; start-height logic now respects these flags.
  - Added extensive NEAR Defuse analytics: event/transaction/receipt/execution tables, derived “silver” datasets for DIP‑4 and NEP‑245, daily asset ingestion, and a “gold” intents metrics view (transfer volume, deposits, withdrawals, netflow).

- Documentation
  - README expanded with full ClickHouse schema definitions, indices, materialized views, and metrics view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->