### PR TITLE
fix: Add more debug logs to catch why indexer suddenly gets stuck

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -28,6 +28,7 @@ pub async fn insert_rows(
     table: &str,
     rows: &[impl Row + serde::Serialize],
 ) -> anyhow::Result<()> {
+    tracing::debug!("Inserting {} rows into table {}", rows.len(), table);
     if rows.is_empty() {
         return Ok(());
     }

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -100,7 +100,6 @@ async fn parse_event(
     receipt_index_in_block: u64,
     receipts_cache_arc: cache::ReceiptsCacheArc,
 ) -> Option<EventRow> {
-    let start = Instant::now();
     let log_trimmed = log.trim();
 
     let tx_hash = match receipts_cache_arc
@@ -124,7 +123,6 @@ async fn parse_event(
                 && (log_trimmed.contains("dip4") || log_trimmed.contains("nep245"))
             {
                 // println!("Event: {}", log_trimmed);
-                tracing::debug!("parse_event {:?}", start.elapsed());
                 return Some(EventRow {
                     block_height: header.height,
                     block_timestamp: header.timestamp,
@@ -147,7 +145,6 @@ async fn parse_event(
             }
         }
     }
-    tracing::debug!("parse_event {:?}", start.elapsed());
     None
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved observability by adding a debug message when inserting rows, including batch size and destination.
  - Reduced log noise by removing per-event timing messages during parsing.
  - No changes to user-facing behavior or APIs; functionality remains the same.
  - Existing instrumentation in event handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->