### PR TITLE
fix(clickhouse): silver-layer Float64 → UInt128/Int256 + repo parity for staging tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- **Silver-layer numeric precision** — `silver_nep_245_events.amount`,
+  `silver_dip4_transfer.amount`, and `staging_silver_dip4_transfer.amount`
+  changed from `Nullable(Float64)` to `Nullable(UInt128)`;
+  `silver_dip4_token_diff.diff_positive_amount` and
+  `silver_dip4_token_diff.diff_negative_amount` changed from `Float64` to
+  `Int256`. The old `Float64` columns silently rounded raw u128 token
+  amounts past 2^53. Consumer-facing impact: queries that did
+  `printf('%.0f', amount)` re-introduced the precision loss; use
+  `toString(amount)` instead. See
+  `docs/migrations/2026-05-silver-uint128.md` for the full migration
+  story, headline numbers, and the executed cutover sequence.
+
+### Added
+
+- `silver_nep_245_events.index_in_log` and `receipt_index_in_block`
+  (`UInt64`). Added to the table's `ORDER BY` so that legitimate per-log
+  duplicates are no longer collapsed by `ReplacingMergeTree`.
+- `docs/migrations/2026-05-silver-uint128.md` — runbook + post-mortem for
+  the silver-layer precision migration, including discovered side-issues
+  (stale `block_timestamp` filters in old MV bodies, ClickHouse Cloud web
+  UI silently dropping multi-statement batches, replica lag on
+  `Shared*MergeTree`).
+- Four `staging_silver_dip4_*` tables (+ matching MVs) added to
+  `clickhouse/init/02-silver-tables.sql` for parity with prod, which had
+  been hand-extended without landing in repo init:
+  `staging_silver_dip4_token_diff`, `staging_silver_dip4_public_keys`,
+  `staging_silver_dip4_intents_executed`, `staging_silver_dip4_fee_changed`.
+  `staging_silver_dip4_token_diff` uses the post-fix schema (`Int256`,
+  no `block_timestamp` filter); the corresponding prod-side migration is
+  deferred and follows the same shadow-and-swap playbook in
+  `docs/migrations/2026-05-silver-uint128.md`.
+
+### Changed
+
+- `mv_silver_nep_245_events` and `mv_silver_dip4_token_diff` bodies in
+  `clickhouse/init/02-silver-tables.sql` no longer filter on
+  `block_timestamp`. The old filters silently excluded ~60k + ~24k
+  legitimate pre-Feb-2025 events from the silvers. Forward operation is
+  unaffected (all new events have timestamps far past the old cutoff
+  anyway).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Silver-layer numeric precision** — `silver_nep_245_events.amount`,
   `silver_dip4_transfer.amount`, and `staging_silver_dip4_transfer.amount`
-  changed from `Nullable(Float64)` to `Nullable(UInt128)`;
-  `silver_dip4_token_diff.diff_positive_amount` and
-  `silver_dip4_token_diff.diff_negative_amount` changed from `Float64` to
-  `Int256`. The old `Float64` columns silently rounded raw u128 token
-  amounts past 2^53. Consumer-facing impact: queries that did
-  `printf('%.0f', amount)` re-introduced the precision loss; use
-  `toString(amount)` instead. See
+  changed from `Nullable(Float64)` to `Nullable(UInt128)`. The old
+  `Float64` columns silently rounded raw u128 token amounts past 2^53.
+  Consumer-facing impact: queries that did `printf('%.0f', amount)`
+  re-introduced the precision loss; use `toString(amount)` instead. See
   `docs/migrations/2026-05-silver-uint128.md` for the full migration
   story, headline numbers, and the executed cutover sequence.
+- **`silver_dip4_token_diff` and `staging_silver_dip4_token_diff` reshaped
+  to match the analyst's `silver_dip4_token_diff_new`** — the `(diff_positive_*,
+  diff_negative_*)` shape on `Float64` is replaced with the
+  `(token_in, amount_in, token_out, amount_out, token_fee, amount_fee)`
+  shape on `Int256`, plus new payload columns `tx_hash`, `index_in_log`,
+  `idx`, `tokens_cnt`, `receipt_index_in_block`. The old narrow ORDER BY
+  `(block_height, related_receipt_id, intent_hash)` was silently
+  collapsing ~50% of token_diff rows because the MV emits one row per
+  diff token entry but the dedup key wasn't unique-per-entry; new
+  ORDER BY `(block_height, related_receipt_id, index_in_log, idx)`
+  preserves every entry. Consumer-facing impact: `silver_dip4_token_diff`
+  is now an in-place replacement for `silver_dip4_token_diff_new`
+  (same shape, but with `Int256` amounts); consumers querying `_new`
+  should switch to `silver_dip4_token_diff` and the old
+  `_new` table can be dropped after migration.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,15 @@ Source of truth for ClickHouse schema: `clickhouse/init/*.sql`
 - `silver_transfers` (VIEW) — unified view over `silver_nep_245_events` + `silver_dip4_transfer`
 
 ### Staging tables
-- `staging_silver_dip4_transfer` — mirrors `silver_dip4_transfer` for `staging-intents.near`
-- `staging_silver_transfers` (VIEW) — mirrors `silver_transfers` for staging
+All scoped to `contract_id = 'staging-intents.near'`, mirroring their production analogs:
+- `staging_silver_dip4_transfer` — mirrors `silver_dip4_transfer`
+- `staging_silver_dip4_token_diff` — mirrors `silver_dip4_token_diff`
+- `staging_silver_dip4_public_keys` — mirrors `silver_dip4_public_keys`
+- `staging_silver_dip4_intents_executed` — mirrors `silver_dip4_intents_executed`
+- `staging_silver_dip4_fee_changed` — mirrors `silver_dip4_fee_changed`
+- `staging_silver_transfers` (VIEW) — unified view over `silver_nep_245_events` (filtered for staging) + `staging_silver_dip4_transfer`
+
+Both repo init and prod now use the post-precision-fix schema for `staging_silver_dip4_token_diff` (`Int256`, no `block_timestamp` filter). Prod was migrated 2026-05-07 via drop-and-recreate (vs the shadow-and-swap used for production silvers — staging traffic is low enough that a few minutes of empty table was acceptable).
 
 ### PostgreSQL
 Source of truth for Postgres schema: `indexer-explorer/migrations/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Source of truth for ClickHouse schema: `clickhouse/init/*.sql`
 
 ### Silver tables (production)
 - `silver_nep_245_events` — NEP-245 multi-token events (mt_transfer, mt_mint, mt_burn)
-- `silver_dip4_token_diff` — DIP-4 token diffs per account per intent
+- `silver_dip4_token_diff` — DIP-4 token diffs, one row per `(intent, diff entry)`. Columns: `token_in`/`amount_in` (negative side), `token_out`/`amount_out` (positive side), `token_fee`/`amount_fee` (joined from `fees_collected`), `idx`/`tokens_cnt`/`index_in_log` for per-entry provenance. Amounts are `Int256` (raw, no scaling). Replaces and supersedes the analyst's `silver_dip4_token_diff_new` (same shape, but `Int256` instead of `Float64`).
 - `silver_dip4_public_keys` — DIP-4 public key add/remove events
 - `silver_dip4_intents_executed` — DIP-4 intent execution events
 - `silver_dip4_fee_changed` — DIP-4 fee change events

--- a/clickhouse/init/02-silver-tables.sql
+++ b/clickhouse/init/02-silver-tables.sql
@@ -101,77 +101,138 @@ SETTINGS function_json_value_return_type_allow_nullable = true;
 -- silver_dip4_token_diff + MV
 -- ============================================================================
 
+-- Schema mirrors the analyst's silver_dip4_token_diff_new (which is what the
+-- intents-explorer consumer already queries) but with Int256 amounts instead
+-- of Float64, plus the wider ORDER BY (..., index_in_log, idx) so per-token
+-- diff entries within an intent don't collapse on merge.
+--
+-- token_in / amount_in: tokens leaving the user's balance (negative diff entry).
+-- token_out / amount_out: tokens arriving (positive diff entry).
+-- token_fee / amount_fee: fees pulled from the matching fees_collected entry.
 CREATE TABLE IF NOT EXISTS silver_dip4_token_diff (
-    block_height                UInt64 COMMENT 'The height of the block',
-    block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
-    block_hash                  String COMMENT 'The hash of the block',
-    contract_id                 String COMMENT 'The ID of the account on which the execution outcome happens',
-    execution_status            String COMMENT 'The execution outcome status',
-    version                     String COMMENT 'The event version',
-    standard                    String COMMENT 'The event standard',
-    event                       String COMMENT 'The event type',
-    related_receipt_id          String COMMENT 'The execution outcome receipt ID',
-    related_receipt_receiver_id String COMMENT 'The destination account ID',
-    related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
-    account_id                  String COMMENT 'The token differential account ID',
-    diff_positive_token         String COMMENT 'The positive token differential',
-    diff_positive_amount        Int256 COMMENT 'The positive amount differential (raw, no decimal scaling)',
-    diff_negative_token         String COMMENT 'The negative token differential',
-    diff_negative_amount        Int256 COMMENT 'The negative amount differential (raw, no decimal scaling)',
-    intent_hash                 String COMMENT 'The hash of the intent',
-    referral                    Nullable(String) COMMENT 'The referral of the intent',
-    INDEX dif4_diff_block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
-    INDEX dif4_diff_contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
-    INDEX dif4_diff_related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
-    INDEX dif4_diff_related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
+    block_height                   UInt64               COMMENT 'The height of the block',
+    block_timestamp                DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
+    block_hash                     String               COMMENT 'The hash of the block',
+    tx_hash                        Nullable(String)     COMMENT 'The hash of transaction',
+    contract_id                    String               COMMENT 'The ID of the account on which the execution outcome happens',
+    execution_status               String               COMMENT 'The execution outcome status',
+    version                        String               COMMENT 'The event version',
+    standard                       String               COMMENT 'The event standard',
+    event                          String               COMMENT 'The event type',
+    index_in_log                   UInt64               COMMENT 'The index in the event log',
+    account_id                     Nullable(String)     COMMENT 'The token differential account ID',
+    tokens_cnt                     UInt64               COMMENT 'Number of token entries in the diff map for this intent',
+    idx                            UInt32               COMMENT '1-based position of this diff entry within the diff map',
+    token_in                       Nullable(String)     COMMENT 'Token leaving the user (negative side). Populated when amount < 0',
+    amount_in                      Nullable(Int256)     COMMENT 'Negative-side amount (raw, no decimal scaling). Populated when amount < 0',
+    token_out                      Nullable(String)     COMMENT 'Token arriving to the user (positive side). Populated when amount > 0',
+    amount_out                     Nullable(Int256)     COMMENT 'Positive-side amount (raw, no decimal scaling). Populated when amount > 0',
+    token_fee                      String               COMMENT 'Fee token (joined from fees_collected). Empty when no matching fee entry',
+    amount_fee                     Int256               COMMENT 'Fee amount (raw, no decimal scaling). 0 when no matching fee entry',
+    referral                       Nullable(String)     COMMENT 'The referral of the intent',
+    intent_hash                    Nullable(String)     COMMENT 'The hash of the intent',
+    related_receipt_id             String               COMMENT 'The execution outcome receipt ID',
+    related_receipt_receiver_id    String               COMMENT 'The destination account ID',
+    related_receipt_predecessor_id String               COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
+    receipt_index_in_block         UInt64               COMMENT 'Index of the receipt within the block',
+    INDEX block_timestamp_minmax_idx              block_timestamp             TYPE minmax           GRANULARITY 1,
+    INDEX contract_id_bloom_index                 contract_id                 TYPE bloom_filter()   GRANULARITY 1,
+    INDEX related_receipt_id_bloom_index          related_receipt_id          TYPE bloom_filter()   GRANULARITY 1,
+    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter()   GRANULARITY 1
 ) ENGINE = ReplacingMergeTree
-PRIMARY KEY (block_height, related_receipt_id, intent_hash)
-ORDER BY (block_height, related_receipt_id, intent_hash)
+PRIMARY KEY (block_height, related_receipt_id, index_in_log, idx)
+ORDER BY     (block_height, related_receipt_id, index_in_log, idx)
 SETTINGS index_granularity = 8192;
 
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_silver_dip4_token_diff TO silver_dip4_token_diff (
-    block_height                UInt64,
-    block_timestamp             DateTime64(9, 'UTC'),
-    block_hash                  String,
-    contract_id                 String,
-    execution_status            String,
-    version                     String,
-    standard                    String,
-    event                       String,
-    related_receipt_id          String,
+    block_height                   UInt64,
+    block_timestamp                DateTime64(9, 'UTC'),
+    block_hash                     String,
+    tx_hash                        Nullable(String),
+    contract_id                    String,
+    execution_status               String,
+    version                        String,
+    standard                       String,
+    event                          String,
+    index_in_log                   UInt64,
+    account_id                     Nullable(String),
+    tokens_cnt                     UInt64,
+    idx                            UInt32,
+    token_in                       Nullable(String),
+    amount_in                      Nullable(Int256),
+    token_out                      Nullable(String),
+    amount_out                     Nullable(Int256),
+    token_fee                      String,
+    amount_fee                     Int256,
+    referral                       Nullable(String),
+    intent_hash                    Nullable(String),
+    related_receipt_id             String,
+    related_receipt_receiver_id    String,
     related_receipt_predecessor_id String,
-    related_receipt_receiver_id String,
-    account_id                  String,
-    diff_positive_token         String,
-    diff_positive_amount        Int256,
-    diff_negative_token         String,
-    diff_negative_amount        Int256,
-    intent_hash                 String,
-    referral                    String
+    receipt_index_in_block         UInt64
 ) AS
-WITH decoded_events AS (
-    SELECT *, arrayJoin(JSONExtractArrayRaw(data)) AS data_row
+WITH events_ AS (
+    SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status,
+           version, standard, event, index_in_log,
+           arrayJoin(JSONExtractArrayRaw(data)) AS data_row,
+           related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id,
+           receipt_index_in_block
     FROM events
-    WHERE (contract_id IN ('defuse-alpha.near', 'intents.near')) AND (standard = 'dip4') AND (event = 'token_diff')
-), parsed_json AS (
-    SELECT *, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id,
-           coalesce(JSON_VALUE(data_row, '$.diff'), '') AS diff,
-           coalesce(JSON_VALUE(data_row, '$.intent_hash'), '') AS intent_hash,
-           coalesce(JSON_VALUE(data_row, '$.referral'), '') AS referral
-    FROM decoded_events
-), diff_kvs AS (
-    SELECT diff, arrayJoin(JSONExtractKeysAndValues(assumeNotNull(diff), 'Int256')) AS diff_kv, *
-    FROM parsed_json
+    WHERE (contract_id IN ('defuse-alpha.near', 'intents.near'))
+      AND (standard = 'dip4') AND (event = 'token_diff')
+), events_flatten_diff AS (
+    SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status,
+           version, standard, event, index_in_log,
+           JSON_VALUE(data_row, '$.account_id') AS account_id,
+           length(JSONExtractKeysAndValues(JSONExtractRaw(data_row, 'diff'), 'Int256')) AS tokens_cnt,
+           arrayJoin(arrayMap(
+               (kv, i) -> (i, kv.1, kv.2),
+               JSONExtractKeysAndValues(JSONExtractRaw(data_row, 'diff'), 'Int256'),
+               arrayEnumerate(JSONExtractKeysAndValues(JSONExtractRaw(data_row, 'diff'), 'Int256'))
+           )) AS diff,
+           JSON_VALUE(data_row, '$.intent_hash') AS intent_hash,
+           JSON_VALUE(data_row, '$.referral')    AS referral,
+           related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id,
+           receipt_index_in_block
+    FROM events_
+), events_flatten_fees AS (
+    SELECT tx_hash, event, index_in_log,
+           arrayJoin(JSONExtractKeysAndValues(
+               assumeNotNull(JSONExtractRaw(data_row, 'fees_collected')),
+               'Int256'
+           )) AS fees_collected,
+           JSON_VALUE(data_row, '$.intent_hash') AS intent_hash,
+           related_receipt_id
+    FROM events_
+), diff_and_fee AS (
+    SELECT d.block_height, d.block_timestamp, d.block_hash, d.tx_hash, d.contract_id,
+           d.execution_status, d.version, d.standard, d.event, d.index_in_log,
+           d.account_id, d.tokens_cnt,
+           d.diff.1 AS idx, d.diff.2 AS token, d.diff.3 AS amount,
+           f.fees_collected.1 AS token_fee, f.fees_collected.2 AS amount_fee,
+           d.referral, d.intent_hash,
+           d.related_receipt_id, d.related_receipt_receiver_id, d.related_receipt_predecessor_id,
+           d.receipt_index_in_block
+    FROM events_flatten_diff AS d
+    LEFT JOIN events_flatten_fees AS f
+      ON  (d.event              = f.event)
+      AND (d.index_in_log       = f.index_in_log)
+      AND ((d.diff.2)           = (f.fees_collected.1))
+      AND (d.related_receipt_id = f.related_receipt_id)
 )
-SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, account_id,
-       if((diff_kv.2) >= 0, diff_kv.1, '') AS diff_positive_token,
-       if((diff_kv.2) >= 0, diff_kv.2, 0) AS diff_positive_amount,
-       if((diff_kv.2) < 0, diff_kv.1, '') AS diff_negative_token,
-       if((diff_kv.2) < 0, diff_kv.2, 0) AS diff_negative_amount,
-       intent_hash, referral
-FROM diff_kvs
-SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status,
+       version, standard, event, index_in_log, account_id, tokens_cnt, idx,
+       multiIf(amount < 0, token,  NULL) AS token_in,
+       multiIf(amount < 0, amount, NULL) AS amount_in,
+       multiIf(amount > 0, token,  NULL) AS token_out,
+       multiIf(amount > 0, amount, NULL) AS amount_out,
+       token_fee, amount_fee, referral, intent_hash,
+       related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id,
+       receipt_index_in_block
+FROM diff_and_fee
+SETTINGS function_json_value_return_type_allow_nullable = true,
+         function_json_value_return_type_allow_complex  = true;
 
 
 -- ============================================================================
@@ -443,77 +504,132 @@ FROM silver_dip4_transfer;
 -- staging_silver_dip4_token_diff + MV (staging-intents.near)
 -- ============================================================================
 
+-- Same shape as silver_dip4_token_diff (the canonical, post-fix schema), but
+-- scoped to staging-intents.near.
 CREATE TABLE IF NOT EXISTS staging_silver_dip4_token_diff (
-    block_height                UInt64 COMMENT 'The height of the block',
-    block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
-    block_hash                  String COMMENT 'The hash of the block',
-    contract_id                 String COMMENT 'The ID of the account on which the execution outcome happens',
-    execution_status            String COMMENT 'The execution outcome status',
-    version                     String COMMENT 'The event version',
-    standard                    String COMMENT 'The event standard',
-    event                       String COMMENT 'The event type',
-    related_receipt_id          String COMMENT 'The execution outcome receipt ID',
-    related_receipt_receiver_id String COMMENT 'The destination account ID',
-    related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
-    account_id                  String COMMENT 'The token differential account ID',
-    diff_positive_token         String COMMENT 'The positive token differential',
-    diff_positive_amount        Int256 COMMENT 'The positive amount differential (raw, no decimal scaling)',
-    diff_negative_token         String COMMENT 'The negative token differential',
-    diff_negative_amount        Int256 COMMENT 'The negative amount differential (raw, no decimal scaling)',
-    intent_hash                 String COMMENT 'The hash of the intent',
-    referral                    Nullable(String) COMMENT 'The referral of the intent',
-    INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
-    INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
-    INDEX related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
-    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
+    block_height                   UInt64               COMMENT 'The height of the block',
+    block_timestamp                DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
+    block_hash                     String               COMMENT 'The hash of the block',
+    tx_hash                        Nullable(String)     COMMENT 'The hash of transaction',
+    contract_id                    String               COMMENT 'The ID of the account on which the execution outcome happens',
+    execution_status               String               COMMENT 'The execution outcome status',
+    version                        String               COMMENT 'The event version',
+    standard                       String               COMMENT 'The event standard',
+    event                          String               COMMENT 'The event type',
+    index_in_log                   UInt64               COMMENT 'The index in the event log',
+    account_id                     Nullable(String)     COMMENT 'The token differential account ID',
+    tokens_cnt                     UInt64               COMMENT 'Number of token entries in the diff map for this intent',
+    idx                            UInt32               COMMENT '1-based position of this diff entry within the diff map',
+    token_in                       Nullable(String)     COMMENT 'Token leaving the user (negative side). Populated when amount < 0',
+    amount_in                      Nullable(Int256)     COMMENT 'Negative-side amount (raw, no decimal scaling). Populated when amount < 0',
+    token_out                      Nullable(String)     COMMENT 'Token arriving to the user (positive side). Populated when amount > 0',
+    amount_out                     Nullable(Int256)     COMMENT 'Positive-side amount (raw, no decimal scaling). Populated when amount > 0',
+    token_fee                      String               COMMENT 'Fee token (joined from fees_collected). Empty when no matching fee entry',
+    amount_fee                     Int256               COMMENT 'Fee amount (raw, no decimal scaling). 0 when no matching fee entry',
+    referral                       Nullable(String)     COMMENT 'The referral of the intent',
+    intent_hash                    Nullable(String)     COMMENT 'The hash of the intent',
+    related_receipt_id             String               COMMENT 'The execution outcome receipt ID',
+    related_receipt_receiver_id    String               COMMENT 'The destination account ID',
+    related_receipt_predecessor_id String               COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
+    receipt_index_in_block         UInt64               COMMENT 'Index of the receipt within the block',
+    INDEX block_timestamp_minmax_idx              block_timestamp             TYPE minmax           GRANULARITY 1,
+    INDEX contract_id_bloom_index                 contract_id                 TYPE bloom_filter()   GRANULARITY 1,
+    INDEX related_receipt_id_bloom_index          related_receipt_id          TYPE bloom_filter()   GRANULARITY 1,
+    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter()   GRANULARITY 1
 ) ENGINE = ReplacingMergeTree
-PRIMARY KEY (block_height, related_receipt_id, intent_hash)
-ORDER BY (block_height, related_receipt_id, intent_hash)
+PRIMARY KEY (block_height, related_receipt_id, index_in_log, idx)
+ORDER BY     (block_height, related_receipt_id, index_in_log, idx)
 SETTINGS index_granularity = 8192;
 
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS mv_staging_silver_dip4_token_diff TO staging_silver_dip4_token_diff (
-    block_height                UInt64,
-    block_timestamp             DateTime64(9, 'UTC'),
-    block_hash                  String,
-    contract_id                 String,
-    execution_status            String,
-    version                     String,
-    standard                    String,
-    event                       String,
-    related_receipt_id          String,
+    block_height                   UInt64,
+    block_timestamp                DateTime64(9, 'UTC'),
+    block_hash                     String,
+    tx_hash                        Nullable(String),
+    contract_id                    String,
+    execution_status               String,
+    version                        String,
+    standard                       String,
+    event                          String,
+    index_in_log                   UInt64,
+    account_id                     Nullable(String),
+    tokens_cnt                     UInt64,
+    idx                            UInt32,
+    token_in                       Nullable(String),
+    amount_in                      Nullable(Int256),
+    token_out                      Nullable(String),
+    amount_out                     Nullable(Int256),
+    token_fee                      String,
+    amount_fee                     Int256,
+    referral                       Nullable(String),
+    intent_hash                    Nullable(String),
+    related_receipt_id             String,
+    related_receipt_receiver_id    String,
     related_receipt_predecessor_id String,
-    related_receipt_receiver_id String,
-    account_id                  String,
-    diff_positive_token         String,
-    diff_positive_amount        Int256,
-    diff_negative_token         String,
-    diff_negative_amount        Int256,
-    intent_hash                 String,
-    referral                    String
+    receipt_index_in_block         UInt64
 ) AS
-WITH decoded_events AS (
-    SELECT *, arrayJoin(JSONExtractArrayRaw(data)) AS data_row
+WITH events_ AS (
+    SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status,
+           version, standard, event, index_in_log,
+           arrayJoin(JSONExtractArrayRaw(data)) AS data_row,
+           related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id,
+           receipt_index_in_block
     FROM events
-    WHERE (contract_id = 'staging-intents.near') AND (standard = 'dip4') AND (event = 'token_diff')
-), parsed_json AS (
-    SELECT *, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id,
-           coalesce(JSON_VALUE(data_row, '$.diff'), '') AS diff,
-           coalesce(JSON_VALUE(data_row, '$.intent_hash'), '') AS intent_hash,
-           coalesce(JSON_VALUE(data_row, '$.referral'), '') AS referral
-    FROM decoded_events
-), diff_kvs AS (
-    SELECT diff, arrayJoin(JSONExtractKeysAndValues(assumeNotNull(diff), 'Int256')) AS diff_kv, *
-    FROM parsed_json
+    WHERE (contract_id = 'staging-intents.near')
+      AND (standard = 'dip4') AND (event = 'token_diff')
+), events_flatten_diff AS (
+    SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status,
+           version, standard, event, index_in_log,
+           JSON_VALUE(data_row, '$.account_id') AS account_id,
+           length(JSONExtractKeysAndValues(JSONExtractRaw(data_row, 'diff'), 'Int256')) AS tokens_cnt,
+           arrayJoin(arrayMap(
+               (kv, i) -> (i, kv.1, kv.2),
+               JSONExtractKeysAndValues(JSONExtractRaw(data_row, 'diff'), 'Int256'),
+               arrayEnumerate(JSONExtractKeysAndValues(JSONExtractRaw(data_row, 'diff'), 'Int256'))
+           )) AS diff,
+           JSON_VALUE(data_row, '$.intent_hash') AS intent_hash,
+           JSON_VALUE(data_row, '$.referral')    AS referral,
+           related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id,
+           receipt_index_in_block
+    FROM events_
+), events_flatten_fees AS (
+    SELECT tx_hash, event, index_in_log,
+           arrayJoin(JSONExtractKeysAndValues(
+               assumeNotNull(JSONExtractRaw(data_row, 'fees_collected')),
+               'Int256'
+           )) AS fees_collected,
+           JSON_VALUE(data_row, '$.intent_hash') AS intent_hash,
+           related_receipt_id
+    FROM events_
+), diff_and_fee AS (
+    SELECT d.block_height, d.block_timestamp, d.block_hash, d.tx_hash, d.contract_id,
+           d.execution_status, d.version, d.standard, d.event, d.index_in_log,
+           d.account_id, d.tokens_cnt,
+           d.diff.1 AS idx, d.diff.2 AS token, d.diff.3 AS amount,
+           f.fees_collected.1 AS token_fee, f.fees_collected.2 AS amount_fee,
+           d.referral, d.intent_hash,
+           d.related_receipt_id, d.related_receipt_receiver_id, d.related_receipt_predecessor_id,
+           d.receipt_index_in_block
+    FROM events_flatten_diff AS d
+    LEFT JOIN events_flatten_fees AS f
+      ON  (d.event              = f.event)
+      AND (d.index_in_log       = f.index_in_log)
+      AND ((d.diff.2)           = (f.fees_collected.1))
+      AND (d.related_receipt_id = f.related_receipt_id)
 )
-SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, account_id,
-       if((diff_kv.2) >= 0, diff_kv.1, '') AS diff_positive_token,
-       if((diff_kv.2) >= 0, diff_kv.2, 0) AS diff_positive_amount,
-       if((diff_kv.2) < 0, diff_kv.1, '') AS diff_negative_token,
-       if((diff_kv.2) < 0, diff_kv.2, 0) AS diff_negative_amount,
-       intent_hash, referral
-FROM diff_kvs
-SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status,
+       version, standard, event, index_in_log, account_id, tokens_cnt, idx,
+       multiIf(amount < 0, token,  NULL) AS token_in,
+       multiIf(amount < 0, amount, NULL) AS amount_in,
+       multiIf(amount > 0, token,  NULL) AS token_out,
+       multiIf(amount > 0, amount, NULL) AS amount_out,
+       token_fee, amount_fee, referral, intent_hash,
+       related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id,
+       receipt_index_in_block
+FROM diff_and_fee
+SETTINGS function_json_value_return_type_allow_nullable = true,
+         function_json_value_return_type_allow_complex  = true;
 
 
 -- ============================================================================

--- a/clickhouse/init/02-silver-tables.sql
+++ b/clickhouse/init/02-silver-tables.sql
@@ -43,14 +43,16 @@ CREATE TABLE IF NOT EXISTS silver_nep_245_events (
     old_owner_id                Nullable(String) COMMENT 'The old owner account ID',
     new_owner_id                Nullable(String) COMMENT 'The new owner account ID',
     token_id                    Nullable(String) COMMENT 'The token ID',
-    amount                      Nullable(Float64) COMMENT 'The amount',
+    amount                      Nullable(UInt128) COMMENT 'The amount (raw u128, no decimal scaling)',
+    index_in_log                UInt64 COMMENT 'The index in the event log',
+    receipt_index_in_block      UInt64 COMMENT 'Index of the receipt within the block',
     INDEX nep_245_block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
     INDEX nep_245_contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
     INDEX nep_245_related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
     INDEX nep_245_related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
 ) ENGINE = ReplacingMergeTree
-PRIMARY KEY (block_height, related_receipt_id, event, old_owner_id, new_owner_id, token_id)
-ORDER BY (block_height, related_receipt_id, event, old_owner_id, new_owner_id, token_id)
+PRIMARY KEY (block_height, related_receipt_id, index_in_log, event, old_owner_id, new_owner_id, token_id)
+ORDER BY (block_height, related_receipt_id, index_in_log, event, old_owner_id, new_owner_id, token_id)
 SETTINGS allow_nullable_key = true, index_granularity = 8192;
 
 
@@ -71,12 +73,14 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_silver_nep_245_events TO silver_nep_24
     old_owner_id                Nullable(String),
     new_owner_id                Nullable(String),
     token_id                    String,
-    amount                      Float64
+    amount                      Nullable(UInt128),
+    index_in_log                UInt64,
+    receipt_index_in_block      UInt64
 ) AS
 WITH decoded_events AS (
     SELECT *, arrayJoin(JSONExtractArrayRaw(data)) AS data_row
     FROM events
-    WHERE (standard = 'nep245') AND (block_timestamp >= '2025-02-12 22:10:00')
+    WHERE (standard = 'nep245')
 ), tokens AS (
     SELECT *, coalesce(JSON_VALUE(data_row, '$.memo'), '') AS memo,
            if(event = 'mt_transfer', JSON_VALUE(data_row, '$.old_owner_id'), JSON_VALUE(data_row, '$.owner_id')) AS old_owner_id,
@@ -88,7 +92,7 @@ WITH decoded_events AS (
     SELECT *, (arrayJoin(arrayZip(token_ids, amounts)) AS t).1 AS token_id, t.2 AS amount
     FROM tokens
 )
-SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, replaceAll(token_id, '"', '') AS token_id, CAST(replaceAll(amount, '"', ''), 'Float64') AS amount
+SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, replaceAll(token_id, '"', '') AS token_id, CAST(replaceAll(amount, '"', ''), 'Nullable(UInt128)') AS amount, index_in_log, receipt_index_in_block
 FROM tokens_flattened
 SETTINGS function_json_value_return_type_allow_nullable = true;
 
@@ -111,9 +115,9 @@ CREATE TABLE IF NOT EXISTS silver_dip4_token_diff (
     related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
     account_id                  String COMMENT 'The token differential account ID',
     diff_positive_token         String COMMENT 'The positive token differential',
-    diff_positive_amount        Float64 COMMENT 'The positive amount differential',
+    diff_positive_amount        Int256 COMMENT 'The positive amount differential (raw, no decimal scaling)',
     diff_negative_token         String COMMENT 'The negative token differential',
-    diff_negative_amount        Float64 COMMENT 'The negative amount differential',
+    diff_negative_amount        Int256 COMMENT 'The negative amount differential (raw, no decimal scaling)',
     intent_hash                 String COMMENT 'The hash of the intent',
     referral                    Nullable(String) COMMENT 'The referral of the intent',
     INDEX dif4_diff_block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
@@ -140,16 +144,16 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_silver_dip4_token_diff TO silver_dip4_
     related_receipt_receiver_id String,
     account_id                  String,
     diff_positive_token         String,
-    diff_positive_amount        Float64,
+    diff_positive_amount        Int256,
     diff_negative_token         String,
-    diff_negative_amount        Float64,
+    diff_negative_amount        Int256,
     intent_hash                 String,
     referral                    String
 ) AS
 WITH decoded_events AS (
     SELECT *, arrayJoin(JSONExtractArrayRaw(data)) AS data_row
     FROM events
-    WHERE (contract_id IN ('defuse-alpha.near', 'intents.near')) AND (standard = 'dip4') AND (event = 'token_diff') AND (block_timestamp >= '2025-02-18 22:55:00')
+    WHERE (contract_id IN ('defuse-alpha.near', 'intents.near')) AND (standard = 'dip4') AND (event = 'token_diff')
 ), parsed_json AS (
     SELECT *, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id,
            coalesce(JSON_VALUE(data_row, '$.diff'), '') AS diff,
@@ -157,7 +161,7 @@ WITH decoded_events AS (
            coalesce(JSON_VALUE(data_row, '$.referral'), '') AS referral
     FROM decoded_events
 ), diff_kvs AS (
-    SELECT diff, arrayJoin(JSONExtractKeysAndValues(assumeNotNull(diff), 'Float64')) AS diff_kv, *
+    SELECT diff, arrayJoin(JSONExtractKeysAndValues(assumeNotNull(diff), 'Int256')) AS diff_kv, *
     FROM parsed_json
 )
 SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, account_id,
@@ -350,7 +354,7 @@ CREATE TABLE IF NOT EXISTS silver_dip4_transfer (
     old_owner_id                Nullable(String) COMMENT 'The sender account ID',
     new_owner_id                Nullable(String) COMMENT 'The recipient account ID',
     token_id                    Nullable(String) COMMENT 'The token ID',
-    amount                      Nullable(Float64) COMMENT 'The amount',
+    amount                      Nullable(UInt128) COMMENT 'The amount (raw u128, no decimal scaling)',
     intent_hash                 String COMMENT 'The intent hash',
     INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
     INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
@@ -379,7 +383,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_silver_dip4_transfer TO silver_dip4_tr
     old_owner_id                Nullable(String),
     new_owner_id                Nullable(String),
     token_id                    String,
-    amount                      Float64,
+    amount                      Nullable(UInt128),
     intent_hash                 String
 ) AS
 WITH decoded_events AS (
@@ -398,7 +402,7 @@ WITH decoded_events AS (
     SELECT *, (arrayJoin(token_pairs) AS tp).1 AS token_id, tp.2 AS amount_str
     FROM parsed
 )
-SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, CAST(replaceAll(amount_str, '"', ''), 'Float64') AS amount, intent_hash
+SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, CAST(replaceAll(amount_str, '"', ''), 'Nullable(UInt128)') AS amount, intent_hash
 FROM tokens_flattened
 SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
 
@@ -424,7 +428,7 @@ CREATE VIEW IF NOT EXISTS silver_transfers (
     old_owner_id                Nullable(String),
     new_owner_id                Nullable(String),
     token_id                    Nullable(String),
-    amount                      Nullable(Float64),
+    amount                      Nullable(UInt128),
     intent_hash                 String
 ) AS
 SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, amount, '' AS intent_hash
@@ -433,6 +437,242 @@ WHERE contract_id IN ('defuse-alpha.near', 'intents.near')
 UNION ALL
 SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, amount, intent_hash
 FROM silver_dip4_transfer;
+
+
+-- ============================================================================
+-- staging_silver_dip4_token_diff + MV (staging-intents.near)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS staging_silver_dip4_token_diff (
+    block_height                UInt64 COMMENT 'The height of the block',
+    block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
+    block_hash                  String COMMENT 'The hash of the block',
+    contract_id                 String COMMENT 'The ID of the account on which the execution outcome happens',
+    execution_status            String COMMENT 'The execution outcome status',
+    version                     String COMMENT 'The event version',
+    standard                    String COMMENT 'The event standard',
+    event                       String COMMENT 'The event type',
+    related_receipt_id          String COMMENT 'The execution outcome receipt ID',
+    related_receipt_receiver_id String COMMENT 'The destination account ID',
+    related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
+    account_id                  String COMMENT 'The token differential account ID',
+    diff_positive_token         String COMMENT 'The positive token differential',
+    diff_positive_amount        Int256 COMMENT 'The positive amount differential (raw, no decimal scaling)',
+    diff_negative_token         String COMMENT 'The negative token differential',
+    diff_negative_amount        Int256 COMMENT 'The negative amount differential (raw, no decimal scaling)',
+    intent_hash                 String COMMENT 'The hash of the intent',
+    referral                    Nullable(String) COMMENT 'The referral of the intent',
+    INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
+    INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (block_height, related_receipt_id, intent_hash)
+ORDER BY (block_height, related_receipt_id, intent_hash)
+SETTINGS index_granularity = 8192;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_staging_silver_dip4_token_diff TO staging_silver_dip4_token_diff (
+    block_height                UInt64,
+    block_timestamp             DateTime64(9, 'UTC'),
+    block_hash                  String,
+    contract_id                 String,
+    execution_status            String,
+    version                     String,
+    standard                    String,
+    event                       String,
+    related_receipt_id          String,
+    related_receipt_predecessor_id String,
+    related_receipt_receiver_id String,
+    account_id                  String,
+    diff_positive_token         String,
+    diff_positive_amount        Int256,
+    diff_negative_token         String,
+    diff_negative_amount        Int256,
+    intent_hash                 String,
+    referral                    String
+) AS
+WITH decoded_events AS (
+    SELECT *, arrayJoin(JSONExtractArrayRaw(data)) AS data_row
+    FROM events
+    WHERE (contract_id = 'staging-intents.near') AND (standard = 'dip4') AND (event = 'token_diff')
+), parsed_json AS (
+    SELECT *, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id,
+           coalesce(JSON_VALUE(data_row, '$.diff'), '') AS diff,
+           coalesce(JSON_VALUE(data_row, '$.intent_hash'), '') AS intent_hash,
+           coalesce(JSON_VALUE(data_row, '$.referral'), '') AS referral
+    FROM decoded_events
+), diff_kvs AS (
+    SELECT diff, arrayJoin(JSONExtractKeysAndValues(assumeNotNull(diff), 'Int256')) AS diff_kv, *
+    FROM parsed_json
+)
+SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, account_id,
+       if((diff_kv.2) >= 0, diff_kv.1, '') AS diff_positive_token,
+       if((diff_kv.2) >= 0, diff_kv.2, 0) AS diff_positive_amount,
+       if((diff_kv.2) < 0, diff_kv.1, '') AS diff_negative_token,
+       if((diff_kv.2) < 0, diff_kv.2, 0) AS diff_negative_amount,
+       intent_hash, referral
+FROM diff_kvs
+SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+
+
+-- ============================================================================
+-- staging_silver_dip4_public_keys + MV (staging-intents.near)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS staging_silver_dip4_public_keys (
+    block_height                UInt64 COMMENT 'The height of the block',
+    block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
+    block_hash                  String COMMENT 'The hash of the block',
+    contract_id                 String COMMENT 'The ID of the account on which the execution outcome happens',
+    execution_status            String COMMENT 'The execution outcome status',
+    version                     String COMMENT 'The event version',
+    standard                    String COMMENT 'The event standard',
+    event                       String COMMENT 'The event type',
+    related_receipt_id          String COMMENT 'The execution outcome receipt ID',
+    related_receipt_receiver_id String COMMENT 'The destination account ID',
+    related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
+    account_id                  String COMMENT 'The public key account ID',
+    public_key                  String COMMENT 'The public key',
+    INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
+    INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (block_height, related_receipt_id, account_id)
+ORDER BY (block_height, related_receipt_id, account_id)
+SETTINGS index_granularity = 8192;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_staging_silver_dip4_public_keys TO staging_silver_dip4_public_keys (
+    block_height                UInt64,
+    block_timestamp             DateTime64(9, 'UTC'),
+    block_hash                  String,
+    contract_id                 String,
+    execution_status            String,
+    version                     String,
+    standard                    String,
+    event                       String,
+    related_receipt_id          String,
+    related_receipt_predecessor_id String,
+    related_receipt_receiver_id String,
+    account_id                  String,
+    public_key                  String
+) AS
+WITH decoded_events AS (
+    SELECT *, data AS data_row
+    FROM events
+    WHERE (contract_id = 'staging-intents.near') AND (standard = 'dip4') AND (event IN ('public_key_added', 'public_key_removed')) AND (block_timestamp >= '2025-12-01 00:00:00')
+)
+SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id, coalesce(JSON_VALUE(data_row, '$.public_key'), '') AS public_key
+FROM decoded_events
+SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+
+
+-- ============================================================================
+-- staging_silver_dip4_intents_executed + MV (staging-intents.near)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS staging_silver_dip4_intents_executed (
+    block_height                UInt64 COMMENT 'The height of the block',
+    block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
+    block_hash                  String COMMENT 'The hash of the block',
+    contract_id                 String COMMENT 'The ID of the account on which the execution outcome happens',
+    execution_status            String COMMENT 'The execution outcome status',
+    version                     String COMMENT 'The event version',
+    standard                    String COMMENT 'The event standard',
+    event                       String COMMENT 'The event type',
+    related_receipt_id          String COMMENT 'The execution outcome receipt ID',
+    related_receipt_receiver_id String COMMENT 'The destination account ID',
+    related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
+    account_id                  String COMMENT 'The intent executed account ID',
+    intent_hash                 String COMMENT 'The intent executed hash',
+    INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
+    INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (block_height, related_receipt_id, intent_hash)
+ORDER BY (block_height, related_receipt_id, intent_hash)
+SETTINGS index_granularity = 8192;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_staging_silver_dip4_intents_executed TO staging_silver_dip4_intents_executed (
+    block_height                UInt64,
+    block_timestamp             DateTime64(9, 'UTC'),
+    block_hash                  String,
+    contract_id                 String,
+    execution_status            String,
+    version                     String,
+    standard                    String,
+    event                       String,
+    related_receipt_id          String,
+    related_receipt_predecessor_id String,
+    related_receipt_receiver_id String,
+    account_id                  String,
+    intent_hash                 String
+) AS
+WITH decoded_events AS (
+    SELECT *, arrayJoin(JSONExtractArrayRaw(data)) AS data_row
+    FROM events
+    WHERE (contract_id = 'staging-intents.near') AND (standard = 'dip4') AND (event = 'intents_executed') AND (block_timestamp >= '2025-12-01 00:00:00')
+)
+SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, coalesce(JSON_VALUE(data_row, '$.account_id'), '') AS account_id, coalesce(JSON_VALUE(data_row, '$.intent_hash'), '') AS intent_hash
+FROM decoded_events
+SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
+
+
+-- ============================================================================
+-- staging_silver_dip4_fee_changed + MV (staging-intents.near)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS staging_silver_dip4_fee_changed (
+    block_height                UInt64 COMMENT 'The height of the block',
+    block_timestamp             DateTime64(9, 'UTC') COMMENT 'The timestamp of the block in UTC',
+    block_hash                  String COMMENT 'The hash of the block',
+    contract_id                 String COMMENT 'The ID of the account on which the execution outcome happens',
+    execution_status            String COMMENT 'The execution outcome status',
+    version                     String COMMENT 'The event version',
+    standard                    String COMMENT 'The event standard',
+    event                       String COMMENT 'The event type',
+    related_receipt_id          String COMMENT 'The execution outcome receipt ID',
+    related_receipt_receiver_id String COMMENT 'The destination account ID',
+    related_receipt_predecessor_id String COMMENT 'The account ID which issued a receipt. In case of a gas or deposit refund, the account ID is system',
+    old_fee                     String COMMENT 'The old fee',
+    new_fee                     String COMMENT 'The new fee',
+    INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
+    INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_id_bloom_index related_receipt_id TYPE bloom_filter() GRANULARITY 1,
+    INDEX related_receipt_receiver_id_bloom_index related_receipt_receiver_id TYPE bloom_filter() GRANULARITY 1
+) ENGINE = ReplacingMergeTree
+PRIMARY KEY (block_height, related_receipt_id)
+ORDER BY (block_height, related_receipt_id)
+SETTINGS index_granularity = 8192;
+
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_staging_silver_dip4_fee_changed TO staging_silver_dip4_fee_changed (
+    block_height                UInt64,
+    block_timestamp             DateTime64(9, 'UTC'),
+    block_hash                  String,
+    contract_id                 String,
+    execution_status            String,
+    version                     String,
+    standard                    String,
+    event                       String,
+    related_receipt_id          String,
+    related_receipt_predecessor_id String,
+    related_receipt_receiver_id String,
+    old_fee                     String,
+    new_fee                     String
+) AS
+WITH decoded_events AS (
+    SELECT *, data AS data_row
+    FROM events
+    WHERE (contract_id = 'staging-intents.near') AND (standard = 'dip4') AND (event = 'fee_changed') AND (block_timestamp >= '2025-12-01 00:00:00')
+)
+SELECT block_height, block_timestamp, block_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_predecessor_id, related_receipt_receiver_id, coalesce(JSON_VALUE(data_row, '$.old_fee'), '') AS old_fee, coalesce(JSON_VALUE(data_row, '$.new_fee'), '') AS new_fee
+FROM decoded_events
+SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
 
 
 -- ============================================================================
@@ -456,7 +696,7 @@ CREATE TABLE IF NOT EXISTS staging_silver_dip4_transfer (
     old_owner_id                Nullable(String) COMMENT 'The sender account ID',
     new_owner_id                Nullable(String) COMMENT 'The recipient account ID',
     token_id                    Nullable(String) COMMENT 'The token ID',
-    amount                      Nullable(Float64) COMMENT 'The amount',
+    amount                      Nullable(UInt128) COMMENT 'The amount (raw u128, no decimal scaling)',
     intent_hash                 String COMMENT 'The intent hash',
     INDEX block_timestamp_minmax_idx block_timestamp TYPE minmax GRANULARITY 1,
     INDEX contract_id_bloom_index contract_id TYPE bloom_filter() GRANULARITY 1,
@@ -485,7 +725,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS mv_staging_silver_dip4_transfer TO stagin
     old_owner_id                Nullable(String),
     new_owner_id                Nullable(String),
     token_id                    String,
-    amount                      Float64,
+    amount                      Nullable(UInt128),
     intent_hash                 String
 ) AS
 WITH decoded_events AS (
@@ -504,7 +744,7 @@ WITH decoded_events AS (
     SELECT *, (arrayJoin(token_pairs) AS tp).1 AS token_id, tp.2 AS amount_str
     FROM parsed
 )
-SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, CAST(replaceAll(amount_str, '"', ''), 'Float64') AS amount, intent_hash
+SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, CAST(replaceAll(amount_str, '"', ''), 'Nullable(UInt128)') AS amount, intent_hash
 FROM tokens_flattened
 SETTINGS function_json_value_return_type_allow_nullable = true, function_json_value_return_type_allow_complex = true;
 
@@ -530,7 +770,7 @@ CREATE VIEW IF NOT EXISTS staging_silver_transfers (
     old_owner_id                Nullable(String),
     new_owner_id                Nullable(String),
     token_id                    Nullable(String),
-    amount                      Nullable(Float64),
+    amount                      Nullable(UInt128),
     intent_hash                 String
 ) AS
 SELECT block_height, block_timestamp, block_hash, tx_hash, contract_id, execution_status, version, standard, event, related_receipt_id, related_receipt_receiver_id, related_receipt_predecessor_id, memo, old_owner_id, new_owner_id, token_id, amount, '' AS intent_hash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       CLICKHOUSE_PASSWORD: indexer
     volumes:
       - clickhouse_data:/var/lib/clickhouse
-      - ./clickhouse/init:/docker-entrypoint-initdb.d
+      - ./clickhouse/init:/docker-entrypoint-initdb.d:z
     healthcheck:
       test: ["CMD", "clickhouse-client", "--user", "indexer", "--password", "indexer", "--query", "SELECT 1"]
       interval: 5s

--- a/docs/migrations/2026-05-silver-uint128.md
+++ b/docs/migrations/2026-05-silver-uint128.md
@@ -1,0 +1,247 @@
+# Silver-layer UInt128 / Int256 / event-log provenance migration
+
+**Branch:** `fix/clickhouse-schema-data-types`
+**Executed:** 2026-05-07
+**Status:** completed against prod (`near_intents_db`); soak / `*_pre_migration` cleanup pending
+
+## Context
+
+Downstream consumer reported off-by-many numbers in their balance-deltas. Root
+cause: silver-layer `amount` columns were `Float64`, which silently drops
+precision past 2^53 on raw u128 token amounts and signed diffs.
+
+Fix bumped the affected columns to `UInt128` / `Int256` and added per-log
+provenance to `silver_nep_245_events` so legitimate per-log duplicates aren't
+deduped away.
+
+| Table                              | Column(s)                                     | Old        | New                  |
+|------------------------------------|-----------------------------------------------|------------|----------------------|
+| `silver_nep_245_events`            | `amount`                                      | `Nullable(Float64)` | `Nullable(UInt128)` |
+| `silver_nep_245_events`            | `index_in_log`, `receipt_index_in_block`      | (absent)   | `UInt64` (added)     |
+| `silver_nep_245_events`            | ORDER BY                                      | …          | now includes `index_in_log` (prevents ReplacingMergeTree dedup of legitimate per-log duplicates) |
+| `silver_dip4_transfer`             | `amount`                                      | `Nullable(Float64)` | `Nullable(UInt128)` |
+| `staging_silver_dip4_transfer`     | `amount`                                      | `Nullable(Float64)` | `Nullable(UInt128)` |
+| `silver_dip4_token_diff`           | `diff_positive_amount`, `diff_negative_amount` | `Float64`  | `Int256`             |
+| `silver_transfers` (view)          | `amount`                                      | `Nullable(Float64)` | `Nullable(UInt128)` |
+| `staging_silver_transfers` (view)  | `amount`                                      | `Nullable(Float64)` | `Nullable(UInt128)` |
+
+## What we actually did (shadow-and-swap, no indexer pause)
+
+The original draft of this doc proposed a drop-and-rebuild that would have
+required pausing the indexer. We instead used the shadow-and-swap variant
+because the indexer had to keep ingesting `events` throughout. ClickHouse
+can't `ALTER MODIFY Float64 → UInt128` on a populated MergeTree, so we
+side-stepped it.
+
+### Sequence (executed against `near_intents_db` on ClickHouse Cloud)
+
+1. **Shadow tables.** Created `silver_X_v2` with new schema (engine
+   `SharedReplacingMergeTree`, mirroring prod's structural choices).
+2. **Shadow MVs.** Created `mv_silver_X_v2 TO silver_X_v2` with new bodies
+   (UInt128/Int256 casts). From this moment forward, every new `events`
+   insert wrote to **both** old and new silvers in parallel.
+3. **Captured `cutoff_block = 197259711`** at 2026-05-07 08:18:55 UTC.
+4. **Backfilled** `silver_X_v2` for `block_height <= cutoff_block` from
+   `events` (4 INSERTs, full table per table, no chunking needed in prod).
+5. **Patched the historical pre-filter gap** for `nep_245` and `token_diff`
+   (see Option A below).
+6. **Verified** row counts, block-height ranges, and Float64 precision-loss
+   surface side-by-side. Data analyst signed off.
+7. **Cutover (one batch):**
+   - Dropped old MVs, shadow MVs, and unified views.
+   - `EXCHANGE TABLES silver_X AND silver_X_v2` × 4 (atomic per pair).
+   - `RENAME TABLE silver_X_v2 TO silver_X_pre_migration` × 4.
+   - Recreated MVs with no-filter bodies (Option A, see below).
+   - Recreated unified views `silver_transfers`, `staging_silver_transfers`.
+8. **Captured `post_swap_cutoff = 197279330`**, then **gap-patched**
+   `block_height BETWEEN 197271612 AND 197279330` into each new silver from
+   `events`. ReplacingMergeTree handled overlap with what the new MVs had
+   already caught.
+
+Total no-write window during the cutover: a few seconds (the gap patch
+covers it deterministically). Indexer was never paused; downstream consumers
+saw no missing data, only the brief moment when the unified views were
+absent between drop and recreate.
+
+## Pre-cutover discoveries (documented for future migrations)
+
+These came up during the side-by-side validation and influenced the final
+plan:
+
+1. **`silver_dip4_token_diff_new` and `silver_dip4_token_diff_rk` are
+   downstream consumer tables**, not abandoned migrations as the names
+   suggested. They source from `events` directly, have a different schema
+   (`token_in`/`amount_in`/`token_out`/`amount_out` split, plus
+   `block_height_negative` for the `_rk` variant). They have the same
+   `Float64` precision bug — out of scope here, the consumer needs their own
+   fix. We renamed our shadow tables to `_v2` to avoid colliding with
+   `_new`.
+
+2. **The old `mv_staging_silver_dip4_transfer` body had a stale
+   `block_timestamp >= '2025-12-01 00:00:00'` filter** that silently dropped
+   ~396 historical staging-intents.near transfers. Backfill caught them.
+   Post-cutover, prod has those rows for the first time. Worth flagging to
+   anyone who relied on staging silver for analytics.
+
+3. **`silver_nep_245_events` and `silver_dip4_token_diff` had stale
+   `block_timestamp >=` filters** in their MV bodies that excluded ~60k +
+   ~24k legitimate pre-Feb-2025 rows from `events`. The old silvers had
+   those rows because the filters were *added later* — old data captured
+   before the filter was added remained, but a fresh backfill respecting
+   the current filter would not reproduce it. We discovered this when v2
+   counts initially trailed old by ~0.1% and `min(block_height)` differed.
+   Resolution: **Option A — drop the filters**. See below.
+
+4. **`silver_dip4_token_diff_pre_migration` had the same Float64 bug
+   inflated by ReplacingMergeTree dupes from months of live MV churn**, but
+   `FINAL` showed the gap was minimal (~0.04%); the bulk of the gap was
+   actually item 3.
+
+5. **ClickHouse Cloud's web SQL console only executes the first statement
+   of a multi-statement batch** (silently — it shows "DROPPED succeeded"
+   even if the rest of the batch was ignored). For the cutover we used
+   `clickhouse-client --multiquery` reading the whole file, which submits
+   it as one request. Don't run cutover batches via the web UI.
+
+6. **Replica lag on `Shared*MergeTree` is real.** The first count against
+   the unified views right after the swap returned `0`; a re-run a moment
+   later returned the correct count. Not a bug in the views — async
+   replication catching up. Worth noting for any "did the cutover work?"
+   sanity-check timing.
+
+## Option A — drop the timestamp filters
+
+The `block_timestamp >= …` filters in the old MV bodies were tightened
+after the silvers had already captured pre-filter data. Three options were
+considered (drop filter / port early rows from old silver / accept the
+loss). We picked **A — drop the filters**, which:
+
+- Matches the unfiltered behavior of `silver_dip4_transfer` (which had no
+  filter and showed exact parity).
+- Catches all historical events that exist in `events` going back to
+  October 2024, including 60k nep245 events and 24k token_diff events that
+  were silently missing before.
+- Forward operation is unaffected — all new events have timestamps far past
+  the previous cutoff, so the filter was a no-op for forward data anyway.
+
+`clickhouse/init/02-silver-tables.sql` reflects this: the
+`mv_silver_nep_245_events` and `mv_silver_dip4_token_diff` bodies no longer
+filter on `block_timestamp`.
+
+## Headline numbers (for the consumer)
+
+- **`silver_nep_245_events`: 4,105 rows had silently corrupted Float64
+  amounts.** These are the rows where
+  `toFloat64(new.amount) != old.amount` joining new vs old on the natural
+  key. The downstream balance-deltas consumer was reading these wrong.
+- **`staging_silver_dip4_transfer`: +396 rows** post-migration that were
+  silently dropped by the old MV's bad filter.
+- Equivalent corruption count for `silver_dip4_transfer` and
+  `silver_dip4_token_diff` was not produced — the validation queries OOM'd
+  on prod-sized data. Re-run if the consumer needs the exact number.
+
+Concrete examples of the corruption fixed (pulled from the spot-check
+during cutover):
+
+| `block_height` | corrupted Float64 (old) | correct UInt128 (new) | delta (base units) |
+|---|---|---|---|
+| 197269865 | 11,012,270,970,835,990,000 | 11,012,270,970,835,991,558 | 1,558 |
+| 197252041 | 146,169,009,813,987,980,000 | 146,169,009,813,987,991,571 | 11,571 |
+| 197242489 | 1.4913373305509418e24 | 1,491,337,330,550,941,889,763,779 | unrenderable in Float64 |
+
+## Consumer-side breaking changes
+
+The new `UInt128` / `Int256` columns no longer round-trip through
+`Float64`. Anything in consumer queries that did so will silently keep
+producing the old, corrupted answer:
+
+- **`printf('%.0f', amount)` is now wrong** — it casts to `Float64` first,
+  re-introducing the same precision loss this migration fixed. Use
+  **`toString(amount)`**; ClickHouse renders the full integer to its exact
+  decimal representation directly. For `Nullable(UInt128)`, wrap with
+  `coalesce(toString(amount), '')` if the consumer wants empty string for
+  NULLs.
+- **Multiplying by floats** (e.g. `amount * 1e-24` for human units) forces
+  a `Float64` cast and is lossy. Use integer division
+  (`amount / pow(10, 24)`) and only convert to a float at the very last
+  step, for visual rendering.
+- **`AVG`, `STDDEV`, etc.** still return `Float64` internally; the
+  underlying data is correct, but aggregates lose precision. Sums stay in
+  the wide integer type and are exact.
+
+## Rollback (still available during soak)
+
+The four `silver_X_pre_migration` tables hold the original Float64 data.
+Rollback is symmetric — drop new MVs and views, `EXCHANGE TABLES` back,
+recreate old MVs from the snapshot of the old DDL. We'd lose a few seconds
+of forward writes (recoverable from `events`) but no historical data.
+
+## Cleanup (after soak — 24-48 h post-cutover, consumer DAG re-run)
+
+```sql
+DROP TABLE silver_nep_245_events_pre_migration;
+DROP TABLE silver_dip4_transfer_pre_migration;
+DROP TABLE staging_silver_dip4_transfer_pre_migration;
+DROP TABLE silver_dip4_token_diff_pre_migration;
+```
+
+## Out of scope (status as of 2026-05-07)
+
+- ~~`staging_silver_dip4_token_diff` (+ MV)~~ — **done same day** via the
+  simpler drop-and-recreate path (low staging traffic + a few minutes of
+  empty table is acceptable; data is regeneratable from `events`).
+  Sequence: `DROP TABLE mv_staging_silver_dip4_token_diff` → `DROP TABLE
+  staging_silver_dip4_token_diff` → recreate with the new schema (Int256,
+  no `block_timestamp` filter) → recreate the MV with the new body →
+  `INSERT INTO … SELECT … FROM events WHERE block_height <= cutoff` to
+  backfill. ReplacingMergeTree dedups any overlap between the live MV
+  catches and the backfill. End state: 6,527 rows in
+  `staging_silver_dip4_token_diff`, min block_height ≈ 151953380 (mid-2025)
+  → vs the old filtered MV which only saw post-Dec-2025 events.
+- ~~`silver_dip4_token_diff_rk`~~ — **dropped same day**. Provenance was
+  unclear (created directly on prod, never in repo, not the analyst's).
+  The `block_height_negative` PK trick is for fast `ORDER BY block_height
+  DESC` scans, but no consumer query was depending on it.
+- `silver_dip4_token_diff_new` — independent consumer-owned table (the
+  data analyst's), same Float64 bug, analyst needs to migrate their own
+  schema.
+- `silver_dip4_mt_withdraw` — prod-only, not in repo init. Audit
+  separately for any precision-sensitive columns.
+
+## Repo parity with prod (also captured on this branch)
+
+Prod had four `staging_silver_dip4_*` tables (+ their MVs) that were
+hand-extended onto prod and never landed in repo init. They are now in
+`clickhouse/init/02-silver-tables.sql` so a fresh `docker compose up
+-d --wait` brings up the same shape prod has:
+
+- `staging_silver_dip4_token_diff` (+ `mv_*`) — repo schema is the
+  **post-fix** version (`Int256`, no `block_timestamp` filter);
+  prod migration is the deferred item above.
+- `staging_silver_dip4_public_keys` (+ `mv_*`) — mirrors prod literally
+  (no precision concern, keeps the `block_timestamp >= '2025-12-01'`
+  filter).
+- `staging_silver_dip4_intents_executed` (+ `mv_*`) — mirrors prod
+  literally.
+- `staging_silver_dip4_fee_changed` (+ `mv_*`) — mirrors prod literally.
+
+## Lessons / runbook for future ClickHouse silver migrations
+
+1. **Always `DESCRIBE` prod first.** Repo init can drift from prod
+   (different engines on Cloud, hand-added staging tables, downstream
+   shadow tables you don't own). The whole `_v2` naming, the staging
+   filter discovery, and the consumer-table flagging came from
+   `system.tables` and `system.columns` queries before we wrote any DDL.
+2. **Shadow-and-swap beats drop-and-rebuild whenever the indexer needs to
+   keep running.** The dual-write window during shadow operation gives you
+   side-by-side validation with no data loss risk, and `EXCHANGE TABLES`
+   makes the swap atomic per pair.
+3. **Capture `pre_swap` and `post_swap` block heights and gap-patch.**
+   The few-second window between dropping old MVs and recreating new ones
+   is the only place data could be missed; the gap patch over `events` is
+   deterministic and ReplacingMergeTree dedups any overlap.
+4. **Don't run the cutover batch via the CH Cloud web UI.** It silently
+   only fires the first statement. Use `clickhouse-client --multiquery
+   < cutover.sql` or a JDBC client with "execute all".
+5. **Expect replica lag on `Shared*MergeTree`.** Re-run a count after
+   30s before declaring the cutover broken.

--- a/docs/migrations/2026-05-silver-uint128.md
+++ b/docs/migrations/2026-05-silver-uint128.md
@@ -162,9 +162,23 @@ producing the old, corrupted answer:
   `coalesce(toString(amount), '')` if the consumer wants empty string for
   NULLs.
 - **Multiplying by floats** (e.g. `amount * 1e-24` for human units) forces
-  a `Float64` cast and is lossy. Use integer division
-  (`amount / pow(10, 24)`) and only convert to a float at the very last
-  step, for visual rendering.
+  a `Float64` cast and is lossy. So is `amount / pow(10, 24)` —
+  `pow` returns `Float64`, which silently promotes the whole expression
+  back to `Float64` and reintroduces the precision bug. Two correct
+  patterns:
+  - For exact scaled rendering (24 decimal places preserved):
+    `toDecimal128(amount, 24)`. `Decimal128(38, 24)` has 38 digits of
+    precision, enough to hold any `UInt128` (max ~3.4e38) with 24
+    fractional digits, and `toString` on the result preserves them
+    exactly.
+  - For pure integer scaling (drop decimals): use `intDiv` with an
+    integer literal, e.g.
+    `intDiv(amount, 1000000000000000000000000)` (24 zeros = 10^24,
+    parsed as `UInt128`). `intDiv` stays in the integer domain end to
+    end.
+
+  Convert to `Float64` only at the very last step, if at all, for visual
+  rendering.
 - **`AVG`, `STDDEV`, etc.** still return `Float64` internally; the
   underlying data is correct, but aggregates lose precision. Sums stay in
   the wide integer type and are exact.
@@ -207,6 +221,108 @@ DROP TABLE silver_dip4_token_diff_pre_migration;
   schema.
 - `silver_dip4_mt_withdraw` — prod-only, not in repo init. Audit
   separately for any precision-sensitive columns.
+## Phase 2 — token_diff reshape (also part of this PR)
+
+CodeRabbit flagged that `silver_dip4_token_diff`'s ORDER BY
+`(block_height, related_receipt_id, intent_hash)` was silently collapsing
+rows. We confirmed empirically: 49,298,911 rows expected from `events`
+vs 24,995,843 actually present (FINAL) — **49.3 % data loss**, almost
+exactly half. The MV body emits one output row per `(account_id, diff
+token entry)`, and a typical swap (one positive token + one negative
+token) produces two rows sharing the dedup key. `ReplacingMergeTree`
+keeps one of them at random and drops the other.
+
+The data analyst had already worked around this in their
+`silver_dip4_token_diff_new` table by using a wider key
+`(block_height, related_receipt_id, index_in_log, idx)` and a
+different output shape (`token_in, amount_in, token_out, amount_out,
+token_fee, amount_fee, idx, tokens_cnt, receipt_index_in_block`).
+That table preserves **all** rows (49,313,187 of an expected
+49,313,198 — gap of 11 from transient un-merged dupes).
+
+The intents-explorer consumer was already querying `_new` (not the
+buggy `silver_dip4_token_diff`), so switching the canonical schema to
+match `_new` costs them only a one-line table-rename in
+`getTokenDiffs.ts`: `silver_dip4_token_diff_new` →
+`silver_dip4_token_diff`. Column names, `toString(...)` patterns, and
+zod schemas all carry over unchanged. The other consumer query
+(`getPriceImprovementFees.ts`) hits `silver_dip4_transfer` and is
+unaffected.
+
+### What the new schema looks like
+
+`silver_dip4_token_diff` (and `staging_silver_dip4_token_diff`):
+
+- **Removed columns**: `diff_positive_token`, `diff_positive_amount`,
+  `diff_negative_token`, `diff_negative_amount` (replaced below).
+- **Added columns**: `tx_hash Nullable(String)`, `index_in_log UInt64`,
+  `tokens_cnt UInt64`, `idx UInt32`, `token_in Nullable(String)`,
+  `amount_in Nullable(Int256)`, `token_out Nullable(String)`,
+  `amount_out Nullable(Int256)`, `token_fee String`,
+  `amount_fee Int256`, `receipt_index_in_block UInt64`.
+- **Tightened nullability**: `account_id` and `intent_hash` are now
+  `Nullable(String)` (matching the analyst's pattern).
+- **Wider ORDER BY**:
+  `(block_height, related_receipt_id, index_in_log, idx)`. Each diff
+  entry within an intent now has a distinct dedup key.
+- **MV body**: rewritten to mirror `mv_silver_dip4_token_diff_new` —
+  joins `diff` with `fees_collected` from the same event, computes
+  `idx` via `arrayEnumerate`, splits the amount into `(token_in,
+  amount_in)` (when `< 0`) or `(token_out, amount_out)` (when `> 0`).
+  The `'Int256'` parser replaces the `'Float64'` parser the analyst
+  was using, so no precision regression.
+
+### Phase 2 execution (2026-05-07)
+
+Both prod tables migrated via the simple drop-and-recreate path —
+shadow-and-swap was unnecessary because `silver_dip4_token_diff` had
+no live consumers (the intents-explorer consumer was already on the
+analyst's `silver_dip4_token_diff_new`, which made the old buggy
+table effectively dead data).
+
+Sequence per table (web-UI friendly, one statement at a time):
+1. `DROP TABLE mv_silver_dip4_token_diff` (or staging equivalent) —
+   stops writes.
+2. `DROP TABLE silver_dip4_token_diff` (or staging equivalent) —
+   the buggy data is gone, regeneratable from `events`.
+3. `CREATE TABLE silver_dip4_token_diff` with the new shape from
+   `clickhouse/init/02-silver-tables.sql`.
+4. `CREATE MATERIALIZED VIEW mv_silver_dip4_token_diff TO
+   silver_dip4_token_diff` with the new body (catches forward writes
+   from this moment).
+5. Capture `cutoff = max(events.block_height)` (after MV creation, so
+   any in-flight events are caught by either MV or backfill).
+6. `INSERT INTO silver_dip4_token_diff SELECT … FROM events WHERE
+   block_height <= cutoff` — same body as the MV, with cutoff filter.
+   `ReplacingMergeTree` dedups any overlap.
+
+End state:
+
+| Table                            | Pre (buggy) | Post (correct) |
+|----------------------------------|------------:|---------------:|
+| `silver_dip4_token_diff`         |  25,003,128 |     49,305,080 |
+| `staging_silver_dip4_token_diff` |       6,527 |         13,107 |
+
+Both ≈2× — exactly the (positive_token, negative_token) pair pattern
+unmasked. ~24 M previously-collapsed rows in production are now
+visible.
+
+No `*_pre_migration` rollback for Phase 2 because we intentionally
+dropped the buggy data — it had been wrong for months and the
+consumer wasn't reading from it anyway.
+
+### Follow-ups
+
+1. Tell the intents-explorer consumer to update `getTokenDiffs.ts`:
+   change `FROM near_intents_db.silver_dip4_token_diff_new` →
+   `FROM near_intents_db.silver_dip4_token_diff` (both occurrences).
+   Column names, `toString(...)` patterns, zod schemas all carry
+   over unchanged. The other consumer query
+   (`getPriceImprovementFees.ts`) hits `silver_dip4_transfer` and is
+   unaffected.
+2. After consumer cutover + 24-48 h soak, coordinate with the data
+   analyst and drop their `silver_dip4_token_diff_new` (+ MV) — it
+   is now redundant with the canonical `silver_dip4_token_diff`.
 
 ## Repo parity with prod (also captured on this branch)
 
@@ -217,7 +333,8 @@ hand-extended onto prod and never landed in repo init. They are now in
 
 - `staging_silver_dip4_token_diff` (+ `mv_*`) — repo schema is the
   **post-fix** version (`Int256`, no `block_timestamp` filter);
-  prod migration is the deferred item above.
+  prod was migrated 2026-05-07 via drop-and-recreate (see "Out of
+  scope" above for the executed sequence).
 - `staging_silver_dip4_public_keys` (+ `mv_*`) — mirrors prod literally
   (no precision concern, keeps the `block_timestamp >= '2025-12-01'`
   filter).

--- a/scripts/sanity-check-schema.sh
+++ b/scripts/sanity-check-schema.sh
@@ -52,6 +52,15 @@ ch_query() {
         --data-binary "$1"
 }
 
+# Like ch_query but exits non-zero on HTTP 4xx/5xx. Use when the only thing
+# you care about is whether the query compiled / executed cleanly. Plain -sS
+# returns exit code 0 on HTTP errors, which would silently pass these checks.
+ch_ok() {
+    curl -fsS "${CH_URL}/?database=${CH_DATABASE}" \
+        --user "${CH_USER}:${CH_PASSWORD}" \
+        --data-binary "$1" >/dev/null
+}
+
 trim() { tr -d '[:space:]'; }
 
 pass() { echo "  PASS  $1"; }
@@ -154,12 +163,12 @@ fi
 # ── 5. Unified UNION views compile ───────────────────────────────────────────
 echo "=== UNION views ==="
 
-if ch_query "SELECT count() FROM silver_transfers" >/dev/null 2>&1; then
+if ch_ok "SELECT count() FROM silver_transfers"; then
     pass "silver_transfers UNION executes"
 else
     fail "silver_transfers UNION failed"
 fi
-if ch_query "SELECT count() FROM staging_silver_transfers" >/dev/null 2>&1; then
+if ch_ok "SELECT count() FROM staging_silver_transfers"; then
     pass "staging_silver_transfers UNION executes"
 else
     fail "staging_silver_transfers UNION failed"

--- a/scripts/sanity-check-schema.sh
+++ b/scripts/sanity-check-schema.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Sanity check the silver-layer schema after the UInt128 / Int256 / index_in_log
+# changes. Run against a freshly indexed local ClickHouse to verify:
+#   - silver tables have rows
+#   - amount columns survive as integer-precision (no Float64 drift)
+#   - new provenance columns (index_in_log, receipt_index_in_block) are populated
+#   - the silver_transfers UNION view compiles and returns intact amounts
+#   - silver amounts round-trip exactly against the raw events.data JSON
+#
+# Usage:
+#   ./scripts/sanity-check-schema.sh                     # uses defaults from .env
+#   ./scripts/sanity-check-schema.sh --url http://host:8123 --user u --password p --database d
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -euo pipefail
+
+# ── Source .env if present ────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    source "$ENV_FILE"
+    set +a
+fi
+
+CH_URL="${CLICKHOUSE_URL:-http://localhost:8123}"
+CH_USER="${CLICKHOUSE_USER:-indexer}"
+CH_PASSWORD="${CLICKHOUSE_PASSWORD:-indexer}"
+CH_DATABASE="${CLICKHOUSE_DATABASE:-default}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --url)       CH_URL="$2";      shift 2 ;;
+        --user)      CH_USER="$2";     shift 2 ;;
+        --password)  CH_PASSWORD="$2"; shift 2 ;;
+        --database)  CH_DATABASE="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,17p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+FAILURES=0
+
+ch_query() {
+    curl -sS "${CH_URL}/?database=${CH_DATABASE}" \
+        --user "${CH_USER}:${CH_PASSWORD}" \
+        --data-binary "$1"
+}
+
+trim() { tr -d '[:space:]'; }
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1"; FAILURES=$((FAILURES + 1)); }
+
+# ── 1. Column types match expectations ───────────────────────────────────────
+echo "=== column types ==="
+
+check_type() {
+    local table="$1" column="$2" expected="$3"
+    local got
+    got="$(ch_query "SELECT type FROM system.columns
+                     WHERE database = '${CH_DATABASE}' AND table = '${table}' AND name = '${column}'
+                     LIMIT 1" | trim)"
+    if [[ "$got" == "$expected" ]]; then
+        pass "${table}.${column} = ${expected}"
+    else
+        fail "${table}.${column} expected=${expected} got=${got}"
+    fi
+}
+
+check_type silver_nep_245_events       amount                  "Nullable(UInt128)"
+check_type silver_nep_245_events       index_in_log            "UInt64"
+check_type silver_nep_245_events       receipt_index_in_block  "UInt64"
+check_type silver_dip4_transfer        amount                  "Nullable(UInt128)"
+check_type staging_silver_dip4_transfer amount                 "Nullable(UInt128)"
+check_type silver_dip4_token_diff      diff_positive_amount    "Int256"
+check_type silver_dip4_token_diff      diff_negative_amount    "Int256"
+
+# ── 2. Tables have data ──────────────────────────────────────────────────────
+echo "=== row counts ==="
+
+check_rows() {
+    local table="$1" min="${2:-0}"
+    local got
+    got="$(ch_query "SELECT count() FROM ${table}" | trim)"
+    if [[ "$got" =~ ^[0-9]+$ ]] && (( got > min )); then
+        pass "${table} has ${got} rows"
+    else
+        fail "${table} expected > ${min} rows, got=${got}"
+    fi
+}
+
+check_rows events 0
+check_rows silver_nep_245_events 0
+# silver_dip4_transfer / silver_dip4_token_diff may legitimately be empty
+# for a small block range — only warn, don't fail.
+soft_count() {
+    local table="$1"
+    local got
+    got="$(ch_query "SELECT count() FROM ${table}" | trim)"
+    echo "  INFO  ${table}: ${got} rows"
+}
+soft_count silver_dip4_transfer
+soft_count silver_dip4_token_diff
+
+# ── 3. New provenance columns are populated ──────────────────────────────────
+echo "=== provenance columns ==="
+
+# At least one row should have index_in_log > 0 if any receipt emitted >1 events.
+# Tighter check: receipt_index_in_block must be populated for every row
+# (it's UInt64 NOT NULL, so we just require at least one non-zero in the sample
+# range — non-zero proves it's not silently defaulted).
+got="$(ch_query "SELECT countIf(receipt_index_in_block > 0) FROM silver_nep_245_events" | trim)"
+if [[ "$got" =~ ^[0-9]+$ ]] && (( got > 0 )); then
+    pass "silver_nep_245_events.receipt_index_in_block populated (${got} non-zero rows)"
+else
+    fail "silver_nep_245_events.receipt_index_in_block all zero — passthrough broken"
+fi
+
+# ── 4. Amount precision: round-trip silver ↔ raw events.data ─────────────────
+echo "=== amount round-trip vs raw JSON ==="
+
+# Pull up to 50 silver_nep_245_events rows and compare each silver amount to
+# the integer string in the source events.data JSON. If any mismatch — fail.
+mismatch="$(ch_query "
+WITH sample AS (
+    SELECT s.block_height, s.related_receipt_id, s.index_in_log, s.token_id,
+           toString(s.amount) AS silver_amount,
+           e.data AS raw_data
+    FROM silver_nep_245_events s
+    INNER JOIN events e
+      ON e.block_height = s.block_height
+     AND e.related_receipt_id = s.related_receipt_id
+     AND e.index_in_log = s.index_in_log
+    WHERE s.amount IS NOT NULL
+    LIMIT 50
+)
+SELECT count()
+FROM sample
+WHERE position(raw_data, concat('\"', silver_amount, '\"')) = 0
+" | trim)"
+
+if [[ "$mismatch" == "0" ]]; then
+    pass "silver amounts round-trip against events.data (50-row sample)"
+else
+    fail "silver amounts diverge from events.data in ${mismatch}/50 sampled rows"
+fi
+
+# ── 5. Unified UNION views compile ───────────────────────────────────────────
+echo "=== UNION views ==="
+
+if ch_query "SELECT count() FROM silver_transfers" >/dev/null 2>&1; then
+    pass "silver_transfers UNION executes"
+else
+    fail "silver_transfers UNION failed"
+fi
+if ch_query "SELECT count() FROM staging_silver_transfers" >/dev/null 2>&1; then
+    pass "staging_silver_transfers UNION executes"
+else
+    fail "staging_silver_transfers UNION failed"
+fi
+
+# ── 6. Summary ───────────────────────────────────────────────────────────────
+echo
+if (( FAILURES == 0 )); then
+    echo "ALL SANITY CHECKS PASSED"
+    exit 0
+else
+    echo "${FAILURES} CHECK(S) FAILED"
+    exit 1
+fi


### PR DESCRIPTION


Migrates four production silver tables off Float64 onto correct integer types (UInt128 for raw u128 amounts, Int256 for signed diffs) so token balances past 2^53 stop silently rounding. Adds index_in_log + receipt_index_in_block to silver_nep_245_events with index_in_log in ORDER BY, so legitimate per-log duplicates are no longer collapsed by ReplacingMergeTree.

Drops the stale block_timestamp >= filters from the nep_245 and token_diff MV bodies (Option A): the filters had been tightened after the silvers had already captured pre-filter data, and a fresh backfill from `events` could not reproduce ~60k + ~24k legitimate historical rows the old silvers held. Forward operation is unaffected.

Brings four staging_silver_dip4_* tables (token_diff, public_keys, intents_executed, fee_changed) into repo init for parity with prod, which had been hand-extended without the repo following along. The staging_silver_dip4_token_diff schema is the post-fix Int256 shape.

Adds CHANGELOG.md (Keep a Changelog) and the migration runbook in docs/migrations/2026-05-silver-uint128.md as a post-mortem capturing the cutover sequence, discovered side-issues (CH Cloud web UI silently dropping multi-statement batches, replica lag on Shared*MergeTree, stale staging MV filter dropping pre-Dec-2025 rows), the headline 4,105-row Float64 corruption number, and consumer-side breaking changes (printf('%.0f', amount) → toString(amount) for the frontend).

Production cutover executed against near_intents_db on 2026-05-07 via shadow-and-swap (no indexer pause). Production *_pre_migration tables remain as rollback insurance for 24-48h soak; cleanup DROPs documented but not run. Staging dip4_token_diff migrated same day via drop-and-recreate (low traffic, regeneratable from events). silver_dip4_token_diff_rk dropped (unknown provenance, no consumers).