### PR TITLE
release: 0.5.0 — close chain-delivery gap, bump near-primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-08
+
 ### Fixed
 
+- **Indexer no longer misses chain blocks for cross-shard receipt chains.**
+  Bumped `blocksapi` to v0.2.2, which closes a per-block delivery gap on
+  the upstream stream. Verified end-to-end against block range
+  196366373..196366380: previously absent blocks 196366377 and 196366378
+  are now delivered, and the bridge-deposit chain
+  (`bridge-mng.near` → `omft.near` → `btc.omft.near` → `intents.near`)
+  reconstructs the parent_tx_hash for the leaf receipt at 196366379
+  without RPC fallback. Combined with the NULL-tx_hash drop fix below,
+  the indexer's pipeline now captures these flows end-to-end.
 - **Indexer no longer drops events / receipts / execution_outcomes when the
   parent transaction hash cannot be resolved from the receipt cache.**
   Operators with persistent ClickHouse deployments must run the migration
@@ -62,6 +73,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `Action::TransferToGasKey` and `Action::WithdrawFromGasKey` variants in
+  `indexer-primitives::Action` (and matching arms in
+  `TryFrom<&ActionView>`), introduced in `near-primitives` 0.35.x via
+  the `blocksapi` v0.2.2 bump.
 - `silver_nep_245_events.index_in_log` and `receipt_index_in_block`
   (`UInt64`). Added to the table's `ORDER BY` so that legitimate per-log
   duplicates are no longer collapsed by `ReplacingMergeTree`.
@@ -82,6 +97,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Workspace version `0.4.1` → `0.5.0`.
+- `blocksapi` dependency: tag `v0.2.0` → `v0.2.2`. The newer client closes
+  the chain-block delivery gap noted in the Fixed section. This pulls
+  `near-indexer-primitives` 0.35.x, which is incompatible with
+  `near-lake-framework` 0.7.x's 0.34.x. The Lake data source
+  (`DataSource::Lake`, used for Pinet ingestion) is therefore
+  **temporarily disabled** with a clear `bail!` at startup until
+  `near-lake-framework` ships a 0.35-compatible release. Production
+  BlocksAPI ingestion is unaffected. Tracked as a separate follow-up.
 - **Receipts cache simplified to a single keyspace.** The previous main /
   potential split (with promotion logic) is gone — every tx → receipt-id
   mapping the indexer sees is now written to `receipt_cache:<id>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,14 +1077,14 @@ dependencies = [
 [[package]]
 name = "blocksapi"
 version = "0.2.0"
-source = "git+https://github.com/defuse-protocol/blocksapi-rs.git?tag=v0.2.0#75c44bced2e281bafa23ba155f715c02b036df2c"
+source = "git+https://github.com/defuse-protocol/blocksapi-rs.git?tag=v0.2.2#389ca5e7aca980d2237fe5a0a2ab8a6e39834578"
 dependencies = [
  "anyhow",
  "ciborium",
  "derive_builder",
  "futures",
  "lz4",
- "near-indexer-primitives",
+ "near-indexer-primitives 0.35.1",
  "prost 0.14.1",
  "protoc-bin-vendored",
  "serde",
@@ -2691,7 +2691,7 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexer-common"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "actix-web",
  "actix-web-httpauth",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blocksapi",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-primitives"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blocksapi",
@@ -2786,16 +2786,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3124,6 +3114,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-config-utils"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec642cfa4996ff9d4bc813abe2cb0ace9f42ffbdd3a5e1a551c3acfd1e7d3ce"
+dependencies = [
+ "anyhow",
+ "json_comments",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "near-crypto"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,9 +3139,34 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils",
- "near-schema-checker-lib",
- "near-stdx",
+ "near-config-utils 0.34.1",
+ "near-schema-checker-lib 0.34.1",
+ "near-stdx 0.34.1",
+ "primitive-types",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "near-crypto"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500f7b87df742cc0660c3111b67a6304e5ff95710ceee05e52e5d21e50af57bc"
+dependencies = [
+ "blake2",
+ "borsh",
+ "bs58",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.35.1",
+ "near-schema-checker-lib 0.35.1",
+ "near-stdx 0.35.1",
  "primitive-types",
  "secp256k1",
  "serde",
@@ -3150,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "near-defuse-indexer"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3177,7 +3204,16 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84560d0ae50f85dbaca950bd9a8377061080f95ba04f095eb67a1d2e84a3b51c"
 dependencies = [
- "near-primitives-core",
+ "near-primitives-core 0.34.1",
+]
+
+[[package]]
+name = "near-fmt"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f87e301ffb364a91c51746fc6f7f8ca809c22e1393459ecef560d086b3745a"
+dependencies = [
+ "near-primitives-core 0.35.1",
 ]
 
 [[package]]
@@ -3196,7 +3232,17 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca0f140a9ef21c8b4f0494c0365c8e4e0babd1228ed1875e82018c7ac296a44"
 dependencies = [
- "near-primitives",
+ "near-primitives 0.34.1",
+ "serde",
+]
+
+[[package]]
+name = "near-indexer-primitives"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6135744291ac3ca4dd4901012727ed30d518ddeb4d3faacf2ea6d447f35ae948"
+dependencies = [
+ "near-primitives 0.35.1",
  "serde",
 ]
 
@@ -3216,7 +3262,7 @@ dependencies = [
  "aws-types",
  "derive_builder",
  "futures",
- "near-indexer-primitives",
+ "near-indexer-primitives 0.34.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3236,8 +3282,27 @@ dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core",
- "near-schema-checker-lib",
+ "near-primitives-core 0.34.1",
+ "near-schema-checker-lib 0.34.1",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "near-parameters"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67aae312a7529a6067d67df4dc606622b6bdea3cb94f3ef096c3c4e9c9f28184"
+dependencies = [
+ "borsh",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core 0.35.1",
+ "near-schema-checker-lib 0.35.1",
  "num-rational",
  "serde",
  "serde_repr",
@@ -3264,13 +3329,54 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto",
- "near-fmt",
- "near-parameters",
- "near-primitives-core",
- "near-schema-checker-lib",
- "near-stdx",
- "near-time",
+ "near-crypto 0.34.1",
+ "near-fmt 0.34.1",
+ "near-parameters 0.34.1",
+ "near-primitives-core 0.34.1",
+ "near-schema-checker-lib 0.34.1",
+ "near-stdx 0.34.1",
+ "near-time 0.34.1",
+ "num-rational",
+ "ordered-float 4.6.0",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha3",
+ "smallvec",
+ "smart-default",
+ "strum",
+ "thiserror 2.0.17",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad915ada7ceed7aafa5bfc9ccdc8b57d72972c485f69753c3c37c042d8cd5da"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "bitvec",
+ "borsh",
+ "bytes",
+ "bytesize",
+ "chrono",
+ "derive_builder",
+ "derive_more",
+ "easy-ext",
+ "enum-map",
+ "hex",
+ "itertools 0.14.0",
+ "near-crypto 0.35.1",
+ "near-fmt 0.35.1",
+ "near-parameters 0.35.1",
+ "near-primitives-core 0.35.1",
+ "near-schema-checker-lib 0.35.1",
+ "near-stdx 0.35.1",
+ "near-time 0.35.1",
  "num-rational",
  "ordered-float 4.6.0",
  "primitive-types",
@@ -3300,7 +3406,31 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.34.1",
+ "near-token",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_with",
+ "sha2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840a2e187c91aec833de7a001738bb4b07384ad28e449366ea481a5fe02e861"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh",
+ "bs58",
+ "derive_more",
+ "enum-map",
+ "near-account-id",
+ "near-gas",
+ "near-schema-checker-lib 0.35.1",
  "near-token",
  "num-rational",
  "serde",
@@ -3317,13 +3447,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3652cdf9b13de96d9b23b4ad954652aaa84bdeec5168d8b8c7c229c7d36f41a"
 
 [[package]]
+name = "near-schema-checker-core"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573e560c907f9f89602cf1c748505f1bf93adc1ea11de1eae96579a4e23fee9"
+
+[[package]]
 name = "near-schema-checker-lib"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de81b55e49e8a0bf679f87aee27c6521d5b9a4a73474f753b2a127529ecf78a"
 dependencies = [
- "near-schema-checker-core",
- "near-schema-checker-macro",
+ "near-schema-checker-core 0.34.1",
+ "near-schema-checker-macro 0.34.1",
+]
+
+[[package]]
+name = "near-schema-checker-lib"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4daf9accc21c16ea994d309de64f996afffa2f9846ae7386fe98e3c8043bd1"
+dependencies = [
+ "near-schema-checker-core 0.35.1",
+ "near-schema-checker-macro 0.35.1",
 ]
 
 [[package]]
@@ -3333,16 +3479,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79d63d022e686c6b92426c98f011908037730d557e815d6c813d5686030a6b53"
 
 [[package]]
+name = "near-schema-checker-macro"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee4669ee1f3f8d0fe467c367188d6bf7ba17c215f5b2c0edec593cf4b76bbb3"
+
+[[package]]
 name = "near-stdx"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a501d5074c5c341725fe801ed191f45ef97e0a4d54d6ef5c3e87363930d4d0b1"
 
 [[package]]
+name = "near-stdx"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "586d4ca605c2540a158a4c89d46de0d2649fe52bb94db6a0ddff42a243d37d04"
+
+[[package]]
 name = "near-time"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5458c180f75aba82c50aca6411d46ca085a6e8535895fa1aa84bd15f560cbd43"
+dependencies = [
+ "parking_lot",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "near-time"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e058f77b8ea607c03f77727bd39282bf55222841cd084e921e1037647f38cac"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3487,15 +3656,14 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3519,9 +3687,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -5627,20 +5795,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.90.0"
 
@@ -17,7 +17,7 @@ rust-version = "1.90.0"
 actix-web = "4.5.1"
 actix-web-httpauth = "0.8.2"
 anyhow = "1.0.51"
-blocksapi = { git = "https://github.com/defuse-protocol/blocksapi-rs.git", tag = "v0.2.0" }
+blocksapi = { git = "https://github.com/defuse-protocol/blocksapi-rs.git", tag = "v0.2.2" }
 clap = { version = "4.5", features = ["derive", "env"] }
 dotenv = "0.15.0"
 futures = "0.3.5"

--- a/indexer-clickhouse/src/main.rs
+++ b/indexer-clickhouse/src/main.rs
@@ -73,8 +73,15 @@ async fn main() -> anyhow::Result<()> {
             blocksapi::streamer(blocksapi_config)
         }
         DataSource::Lake => {
-            let lake_config = build_lake_config(&config, start_block).await?;
-            near_lake_framework::streamer(lake_config)
+            // TEMPORARILY DISABLED: blocksapi v0.2.2 pulled near-indexer-primitives 0.35.x,
+            // while near-lake-framework 0.7 is still on 0.34.x — the StreamerMessage types
+            // are nominally distinct across the two indexer-primitives versions, so the
+            // BlocksAPI and Lake match arms can't yield the same stream type. Restore Lake
+            // when near-lake-framework ships a 0.35-compatible release (or we fork/patch).
+            anyhow::bail!(
+                "Lake data source is temporarily disabled while near-lake-framework catches \
+                 up to near-indexer-primitives 0.35. Use DATA_SOURCE=blocksapi for now."
+            )
         }
     };
 
@@ -97,6 +104,9 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Kept around for when Lake is re-enabled (see the bail in the DataSource::Lake match arm
+// above). Don't delete — it preserves the Pinet config wiring.
+#[allow(dead_code)]
 async fn build_lake_config(
     config: &AppConfig,
     start_block: u64,

--- a/indexer-primitives/src/lib.rs
+++ b/indexer-primitives/src/lib.rs
@@ -105,6 +105,8 @@ pub enum Action {
     DeployGlobalContract(near_primitives::action::DeployGlobalContractAction),
     UseGlobalContract(Box<near_primitives::action::UseGlobalContractAction>),
     DeterministicStateInit(Box<near_primitives::action::DeterministicStateInitAction>),
+    TransferToGasKey(Box<near_primitives::action::TransferToGasKeyAction>),
+    WithdrawFromGasKey(Box<near_primitives::action::WithdrawFromGasKeyAction>),
 }
 
 /// Denormalized row for silver-level DIP-4 transfer data.
@@ -155,6 +157,8 @@ impl TryFrom<&near_primitives::views::ActionView> for Action {
             near_primitives::action::Action::DeterministicStateInit(a) => {
                 Action::DeterministicStateInit(a)
             }
+            near_primitives::action::Action::TransferToGasKey(a) => Action::TransferToGasKey(a),
+            near_primitives::action::Action::WithdrawFromGasKey(a) => Action::WithdrawFromGasKey(a),
         })
     }
 }


### PR DESCRIPTION
Cuts a 0.5.0 covering the four concerns merged on this branch:

1. Silver-layer numeric precision migration (Float64 → UInt128/Int256) on silver_nep_245_events, silver_dip4_transfer, staging_silver_dip4_transfer, silver_dip4_token_diff. Executed against prod near_intents_db on 2026-05-07 via shadow-and-swap. Runbook in docs/migrations/2026-05-silver-uint128.md.

2. Indexer drop-fix: events / receipts / execution_outcomes no longer get silently dropped when the receipt cache can't resolve a parent tx hash. Rows now land with NULL parent_transaction_hash, observable via rows_with_null_tx_hash_total. Migration runbook in docs/migrations/2026-05-indexer-null-tx-hash.md.

3. Receipts cache simplified to a single keyspace (main + potential collapsed; promotion logic removed).

4. blocksapi v0.2.0 → v0.2.2 to close a per-block delivery gap that was causing parent_tx resolution failures on cross-shard chains. Verified end-to-end against block range 196366373..196366380: previously missing 196366377 and 196366378 are now delivered, the bridge-deposit chain reconstructs parent_tx_hash for its leaf at 196366379 without RPC fallback. Together with (2) and (3), the indexer's pipeline now captures bridge-style flows correctly.

Side effects of (4):
- near-primitives 0.35.x adds two new Action variants (TransferToGasKey, WithdrawFromGasKey); handled in indexer-primitives::Action enum and TryFrom impl.
- near-lake-framework 0.7 is still on near-indexer-primitives 0.34.x; near-lake-framework ships a 0.35-compatible release. Tracked separately.

Workspace version bumped 0.4.1 → 0.5.0. Full CHANGELOG entry under [0.5.0] - 2026-05-08.