### PR TITLE
update rust version for cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: rust:1.90-bullseye # Debian 11, GLIBC 2.31
+  - name: rust:1.93-bullseye # Debian 11, GLIBC 2.31
     entrypoint: bash
     args:
       - -c


### PR DESCRIPTION
This pull request updates the Rust toolchain version used in the build process to ensure compatibility with newer features and dependencies.

Build environment update:

* Updated the Rust Docker image in `cloudbuild.yaml` from `rust:1.90-bullseye` to `rust:1.93-bullseye` to use a more recent Rust toolchain.